### PR TITLE
fix: handle situation where an Asset has no SHA1 hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ You can see all options by running:
 usage: nexus-repo-asset-lister [OPTIONS]
   -X    Enable debug logging
   -o string
-        Directory to write asset lists to (default "/Current/Working/Directory")
+        Directory to write asset lists to (default "/Users/phorton/Documents/GitHub/sonatype-nexus-community/nexus-repo-asset-lister")
   -password string
         Password used to authenticate to Sonatype Nexus Repository (can also be set using the environment variable NXRM_PASSWORD)
+  -skipped
+        Whether to ouptut skipped assets to a separate '-skipped.json' file
   -url string
         URL including protocol to your Sonatype Nexus Repository Manager (default "http://localhost:8081")
   -username string

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var (
 	currentRuntime  string = runtime.GOOS
 	commit                 = "unknown"
 	outputDirectory string
+	outputSkipped   bool
 	nxrmUrl         string
 	nxrmUsername    string
 	nxrmPassword    string
@@ -64,6 +65,7 @@ func init() {
 	flag.StringVar(&nxrmUsername, "username", "", fmt.Sprintf("Username used to authenticate to Sonatype Nexus Repository (can also be set using the environment variable %s)", ENV_NXRM_USERNAME))
 	flag.StringVar(&nxrmPassword, "password", "", fmt.Sprintf("Password used to authenticate to Sonatype Nexus Repository (can also be set using the environment variable %s)", ENV_NXRM_PASSWORD))
 	flag.StringVar(&outputDirectory, "o", cwd, "Directory to write asset lists to")
+	flag.BoolVar(&outputSkipped, "skipped", false, "Whether to ouptut skipped assets to a separate '-skipped.json' file")
 	flag.BoolVar(&debugLogging, "X", false, "Enable debug logging")
 }
 
@@ -136,7 +138,7 @@ func main() {
 				println(fmt.Sprintf("Failed writing component hashes: %v", err))
 			}
 
-			if len(*skippedAssets) > 0 {
+			if outputSkipped && len(*skippedAssets) > 0 {
 				outputSkippedFilename := fmt.Sprintf("%s-%s-%s-skipped.json", *r.Type, *r.Format, *r.Name)
 				jsonSkippedData, err := json.Marshal(skippedAssets)
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func getAssetsInRepository(server *NxrmServer, repository *ApiRepository) (*[]Co
 				allAssetHashes = append(allAssetHashes, ComponentHash(*a.Checksums.Sha1))
 			}
 		}
-		log.Debug("Component Hashes after page:", len(allAssetHashes), lastContinuationToken)
+		log.Debug(fmt.Sprintf("Component Hashes after page: %d - cont token: %s ", len(allAssetHashes), *lastContinuationToken))
 
 		lastContinuationToken = componentPage.ContinuationToken
 	}

--- a/main.go
+++ b/main.go
@@ -34,8 +34,7 @@ import (
 const (
 	ENV_NXRM_USERNAME = "NXRM_USERNAME"
 	ENV_NXRM_PASSWORD = "NXRM_PASSWORD"
-
-	REPO_TYPE_PROXY = "proxy"
+	REPO_TYPE_PROXY   = "proxy"
 )
 
 var (
@@ -118,13 +117,13 @@ func main() {
 
 	for i, r := range *allRepositories {
 		if r.Type != nil && *r.Type == REPO_TYPE_PROXY {
-			println(fmt.Sprintf("%00d: PROXY of type %s named %s", i, *r.Type, *r.Name))
-			componentHashes, err := getAssetsInRepository(nxrmServer, &r)
+			println(fmt.Sprintf("%00d: PROXY of format %s named %s", i, *r.Format, *r.Name))
+			componentHashes, skippedAssets, err := getAssetsInRepository(nxrmServer, &r)
 			if err != nil {
 				println(fmt.Sprintf("Error: %v", err))
 			}
 
-			println(fmt.Sprintf("  		  %d Compnent Hashes", len(*componentHashes)))
+			println(fmt.Sprintf("   : %0000d Compnent Hashes, %0000d Skipped Assets", len(*componentHashes), len(*skippedAssets)))
 
 			outputFilename := fmt.Sprintf("%s-%s-%s.json", *r.Type, *r.Format, *r.Name)
 			jsonData, err := json.Marshal(componentHashes)
@@ -135,6 +134,19 @@ func main() {
 			err = os.WriteFile(path.Join(outputDirectory, strings.ToLower(outputFilename)), jsonData, os.ModePerm)
 			if err != nil {
 				println(fmt.Sprintf("Failed writing component hashes: %v", err))
+			}
+
+			if len(*skippedAssets) > 0 {
+				outputSkippedFilename := fmt.Sprintf("%s-%s-%s-skipped.json", *r.Type, *r.Format, *r.Name)
+				jsonSkippedData, err := json.Marshal(skippedAssets)
+				if err != nil {
+					println(fmt.Sprintf("Error: %v", err))
+				}
+
+				err = os.WriteFile(path.Join(outputDirectory, strings.ToLower(outputSkippedFilename)), jsonSkippedData, os.ModePerm)
+				if err != nil {
+					println(fmt.Sprintf("Failed writing skipped components: %v", err))
+				}
 			}
 		}
 	}
@@ -197,12 +209,13 @@ func getAllProxyRepositories(server *NxrmServer) (*[]ApiRepository, error) {
 	return &repositories, nil
 }
 
-func getAssetsInRepository(server *NxrmServer, repository *ApiRepository) (*[]ComponentHash, error) {
+func getAssetsInRepository(server *NxrmServer, repository *ApiRepository) (*[]ComponentHash, *[]ApiComponentAsset, error) {
 	allAssetHashes := make([]ComponentHash, 0)
+	skippedAssets := make([]ApiComponentAsset, 0)
 
 	firstComponentPage, err := getAssetsPageForRepository(server, *repository.Name, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, c := range firstComponentPage.Items {
@@ -217,12 +230,22 @@ func getAssetsInRepository(server *NxrmServer, repository *ApiRepository) (*[]Co
 	for lastContinuationToken != nil {
 		componentPage, err := getAssetsPageForRepository(server, *repository.Name, lastContinuationToken)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		for _, c := range firstComponentPage.Items {
 			for _, a := range c.Assets {
-				allAssetHashes = append(allAssetHashes, ComponentHash(*a.Checksums.Sha1))
+				if a.Checksums != nil {
+					if a.Checksums.Sha1 != nil {
+						allAssetHashes = append(allAssetHashes, ComponentHash(*a.Checksums.Sha1))
+					} else {
+						log.Debug(fmt.Sprintf("Skipping Asset (no hash): %s", a.DownloadUrl))
+						skippedAssets = append(skippedAssets, a)
+					}
+				} else {
+					log.Debug(fmt.Sprintf("Skipping Asset (no checksums): %s", a.DownloadUrl))
+					skippedAssets = append(skippedAssets, a)
+				}
 			}
 		}
 		log.Debug(fmt.Sprintf("Component Hashes after page: %d - cont token: %s ", len(allAssetHashes), *lastContinuationToken))
@@ -230,7 +253,7 @@ func getAssetsInRepository(server *NxrmServer, repository *ApiRepository) (*[]Co
 		lastContinuationToken = componentPage.ContinuationToken
 	}
 
-	return &allAssetHashes, nil
+	return &allAssetHashes, &skippedAssets, nil
 }
 
 func getAssetsPageForRepository(server *NxrmServer, repository_name string, continuation_token *string) (*ApiComponentList, error) {

--- a/types.go
+++ b/types.go
@@ -59,10 +59,11 @@ type ApiComponentAssetChecksums struct {
 }
 
 type ApiComponentAsset struct {
-	Id         string                      `json:"Id"`
-	Repository string                      `json:"repository"`
-	Format     string                      `json:"format"`
-	Checksums  *ApiComponentAssetChecksums `json:"checksum"`
+	Id          string                      `json:"Id"`
+	Repository  string                      `json:"repository"`
+	Format      string                      `json:"format"`
+	Checksums   *ApiComponentAssetChecksums `json:"checksum"`
+	DownloadUrl string                      `json:"downloadUrl"`
 }
 
 type ApiComponent struct {


### PR DESCRIPTION
There are some edge case scenarios in some specific formats where SHA1 hashes for assets will not be available. 

These will be safely skipped, but logged to a separate `-skipped.json` if further detail is required.